### PR TITLE
Fix .gitignore VSCode integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,6 +396,3 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
-
-# Visual Studio Code
-.vscode/


### PR DESCRIPTION
There are specific files, such as the tasks.json, that are already covered by GitHub's .gitignore and I didn't realise this in #41 