### PR TITLE
Allow customizing the first line of the report

### DIFF
--- a/Coroner/AdvancedCauseOfDeath.cs
+++ b/Coroner/AdvancedCauseOfDeath.cs
@@ -251,34 +251,32 @@ namespace Coroner
 
         public static string StringifyCauseOfDeath(AdvancedCauseOfDeath? causeOfDeath, Random random)
         {
-            var result = SelectCauseOfDeath(causeOfDeath);
+            var languageTag = SelectCauseOfDeathLanguageTag(causeOfDeath);
 
-            var shouldRandomize = result.Length > 1 && (causeOfDeath == null || !Plugin.Instance.PluginConfig.ShouldUseSeriousDeathMessages());
+            var shouldRandomize = causeOfDeath == null || !Plugin.Instance.PluginConfig.ShouldUseSeriousDeathMessages();
 
             if (shouldRandomize)
             {
-                var index = random.Next(result.Length);
-                return result[index];
+                return Plugin.Instance.LanguageHandler.GetRandomValueByTag(languageTag, random);
             }
             else
             {
-                return result[0];
+                // NOTE: First cause of death in the list should be the "serious" entry.
+                return Plugin.Instance.LanguageHandler.GetFirstValueByTag(languageTag);
             }
         }
 
-        public static string[] SelectCauseOfDeath(AdvancedCauseOfDeath? causeOfDeath)
+        public static string SelectCauseOfDeathLanguageTag(AdvancedCauseOfDeath? causeOfDeath)
         {
-            if (causeOfDeath == null) return Plugin.Instance.LanguageHandler.GetValuesByTag(LanguageHandler.TAG_FUNNY_NOTES);
-
-            // NOTE: First cause of death in the list should be the "serious" entry.
+            if (causeOfDeath == null) return LanguageHandler.TAG_FUNNY_NOTES;
 
             if (AdvancedCauseOfDeath.IsCauseOfDeathRegistered(causeOfDeath))
             {
-                return ((AdvancedCauseOfDeath)causeOfDeath).GetLanguageValues();
+                return ((AdvancedCauseOfDeath)causeOfDeath).GetLanguageTag();
             }
             else
             {
-                return Plugin.Instance.LanguageHandler.GetValuesByTag(LanguageHandler.TAG_DEATH_UNKNOWN);
+                return LanguageHandler.TAG_DEATH_UNKNOWN;
             }
         }
     }
@@ -487,11 +485,6 @@ namespace Coroner
         public string GetLanguageTag()
         {
             return languageTag;
-        }
-
-        public string[] GetLanguageValues()
-        {
-            return Plugin.Instance.LanguageHandler.GetValuesByTag(languageTag);
         }
 
         public override bool Equals(object obj)

--- a/Coroner/LanguageHandler.cs
+++ b/Coroner/LanguageHandler.cs
@@ -233,6 +233,21 @@ namespace Coroner
             return GetValuesByTag(tag)[0];
         }
 
+        public string GetRandomValueByTag(string tag, Random random)
+        {
+            var result = GetValuesByTag(tag);
+
+            // NOTE: obtaining a random number is skipped if there is only one result. This may be relavant for synced randoms.
+            if (result.Length > 1)
+            {
+                var index = random.Next(result.Length);
+                return result[index];
+            }
+
+            // NOTE: Assumes GetValuesByTag always returns a non-empty array.
+            return result[0];
+        }
+
         public string[] GetValuesByTag(string tag)
         {
             if (languageData.Count == 0 && languageCode != DEFAULT_LANGUAGE)

--- a/Coroner/Patch/HUDManagerPatch.cs
+++ b/Coroner/Patch/HUDManagerPatch.cs
@@ -59,7 +59,7 @@ namespace Coroner.Patch
                         {
                             Plugin.Instance.PluginLogger.LogInfo("[REPORT] Player " + playerIndex + " is dead! Replacing notes with Cause of Death...");
                             // Reset the notes.
-                            textMesh.text = Plugin.Instance.LanguageHandler.GetFirstValueByTag(LanguageHandler.TAG_UI_DEATH) + "\n";
+                            textMesh.text = CreateMessagePrefixFromTag(LanguageHandler.TAG_UI_DEATH, syncedRandom) + "\n";
                         }
                         else
                         {
@@ -82,7 +82,7 @@ namespace Coroner.Patch
                         {
                             Plugin.Instance.PluginLogger.LogInfo("[REPORT] Player " + playerIndex + " has no notes! Injecting something funny...");
 
-                            textMesh.text = Plugin.Instance.LanguageHandler.GetFirstValueByTag(LanguageHandler.TAG_UI_NOTES) + "\n";
+                            textMesh.text = CreateMessagePrefixFromTag(LanguageHandler.TAG_UI_NOTES, syncedRandom) + "\n";
                             textMesh.text += "* " + AdvancedDeathTracker.StringifyCauseOfDeath(null, syncedRandom) + "\n";
                         }
                         else
@@ -99,6 +99,17 @@ namespace Coroner.Patch
 
             // We are done with the death tracker, so clear it.
             AdvancedDeathTracker.ClearDeathTracker();
+        }
+
+        private static string CreateMessagePrefixFromTag(string prefixLanguageTag, Random random)
+        {
+            if (Plugin.Instance.PluginConfig.ShouldUseSeriousDeathMessages())
+            {
+                // NOTE: First entry in the list should be the "serious" entry.
+                return Plugin.Instance.LanguageHandler.GetFirstValueByTag(prefixLanguageTag);
+            }
+
+            return Plugin.Instance.LanguageHandler.GetRandomValueByTag(prefixLanguageTag, random);
         }
     }
 }


### PR DESCRIPTION
## Use case
We had this great idea to customize the lang files to replace the _"Cause of death:"_ on the first line of the report with _"Skill issue:"_. However, as not all deaths are necessarily skill issues (although some of them surely are), we found the thought of randomly picking either of those very amusing. Making one of the options a rare/easter-egg kind of thing would be next level, but let's not get ahead of ourselves. Just being able to randomize the first line of the report would be great!

## The issue
To our great disappointment, it turns out, the report only ever uses the first `UINotes` or `UICauseOfDeath` defined in the language XML. A somewhat of a major setback, as this prevents any chance of randomizing the darn thing.

## The solution
Being a persistent bunch of idiots, we didn't let this stop us! When there's a will there's a way!

Rundown of the changes in this PR:
- I could have copy-pasted the logic behind `StringifyCauseOfDeath`/`SelectCauseOfDeath` and called it a day, but that would have been a bit messy.
- Instead, as randomizing the first line and randomizing the note/cause of death is essentially the same logic, it made sense to generalize the pick-translation-value-at-random logic.
- To achieve this, I added a new method `LanguageHandler.GetRandomValueByTag` (similar to `LanguageHandler.GetFirstValueByTag`)
- The current implementation of `SelectCauseOfDeath` happened to get the full list of translation values, which was somewhat incompatible with the idea of generalizing the logic. I needed to tweak this to work only with the language tags instead of getting the full list of values.
- Then, the `StringifyCauseOfDeath` can simply call either `GetRandomValueByTag` or `GetFirstValueByTag`, depending on the value of `shouldRandomize`. The `result.Length > 1` check is now an implementation detail of `GetRandomValueByTag`, so it could be removed from here.
- With those out of the way, the actual changes to the `HUDManagerPatch.cs` are very simple: Instead of always calling `GetFirstValueByTag` with the `TAG_UI_DEATH` and `TAG_UI_NOTES`, use the new `GetRandomValueByTag`.
- To keep things consistent, I added a check for serious notes, which disables the randomization in case serious death messages are enabled.

I tested the changes by adding a bunch of translation variations for `TAG_UI_DEATH` and `TAG_UI_NOTES`, and then proceeding to die in various ways. Seemed to work like a charm, the reports were properly randomized, the first line included.