### PR TITLE
ResetCauseOfDeath API

### DIFF
--- a/Coroner/API.cs
+++ b/Coroner/API.cs
@@ -12,7 +12,7 @@ namespace Coroner
         /// You can set this to a default one (see `Coroner.AdvancedCauseOfDeath`) or a custom one (see `Register()`).
         /// </summary>
         /// <param name="player">The player to set the cause of death for.</param>
-        /// <param name="causeOfDeath">The cause of death to use. Set to `null` to clear.</param>
+        /// <param name="causeOfDeath">The cause of death to use.</param>
         /// <example> SetCauseOfDeath(player, AdvancedCauseOfDeath.Enemy_ForestGiant); </example>
         public static void SetCauseOfDeath(PlayerControllerB player, AdvancedCauseOfDeath? causeOfDeath)
         {
@@ -25,7 +25,7 @@ namespace Coroner
         /// You can set this to a default one (see `Coroner.AdvancedCauseOfDeath`) or a custom one (see `Register()`).
         /// </summary>
         /// <param name="playerId">The ID of the player.</param>
-        /// <param name="causeOfDeath">The cause of death to use. Set to `null` to clear.</param>
+        /// <param name="causeOfDeath">The cause of death to use.</param>
         /// <example> SetCauseOfDeath(0, AdvancedCauseOfDeath.Enemy_ForestGiant); </example>
         public static void SetCauseOfDeath(int playerId, AdvancedCauseOfDeath? causeOfDeath)
         {
@@ -55,6 +55,30 @@ namespace Coroner
         {
             // Call the proper internal method.
             return AdvancedDeathTracker.GetCauseOfDeath(playerId);
+        }
+        
+        /// <summary>
+        /// Resets the cause of death to null for a player object.
+        /// </summary>
+        /// <param name="player">The player to set the cause of death for.</param>
+        /// <returns>The cause of death for the player.</returns>
+        /// <example> GetCauseOfDeath(0); </example>
+        public static void ResetCauseOfDeath(PlayerControllerB player)
+        {
+            // Call the proper internal method.
+            AdvancedDeathTracker.SetCauseOfDeath(player, null, true);
+        }
+        
+        /// <summary>
+        /// Resets the cause of death to null for a player with the given ID.
+        /// </summary>
+        /// <param name="playerId">The ID of the player.</param>
+        /// <returns>The cause of death for the player.</returns>
+        /// <example> GetCauseOfDeath(0); </example>
+        public static void ResetCauseOfDeath(int playerId)
+        {
+            // Call the proper internal method.
+            AdvancedDeathTracker.SetCauseOfDeath(playerId, null, true);
         }
 
         /// <summary>

--- a/Coroner/NetworkRPC.cs
+++ b/Coroner/NetworkRPC.cs
@@ -30,6 +30,11 @@ namespace Coroner
         [ClientRpc]
         public static void BroadcastCauseOfDeathClientRpc(int playerClientId, string? codLanguageTag, bool forceOverride) { 
             Plugin.Instance.PluginLogger.LogDebug($"Client received cause of death via RPC: ({playerClientId}, {(codLanguageTag == null ? "null" : codLanguageTag)})");
+            if (codLanguageTag == null && !forceOverride)
+            {
+                Plugin.Instance.PluginLogger.LogDebug("Resetting cause of death.");
+                AdvancedDeathTracker.StoreLocalCauseOfDeath(playerClientId,null, forceOverride);
+            }
             
             if (codLanguageTag == null || !AdvancedCauseOfDeath.IsTagRegistered(codLanguageTag)) { 
                 Plugin.Instance.PluginLogger.LogError($"Could not deserialize cause of death ({codLanguageTag})");

--- a/MODDING.md
+++ b/MODDING.md
@@ -107,11 +107,17 @@ In `BepInEx/config/EliteMasterEric-Coroner/` in your mod upload, create a file n
     - Retrieves the currently known cause of death for the player by reference, if any.
     - Returns: An `AdvancedCauseOfDeath`, or `null` if no cause of death is known.
 - `Coroner.API.SetCauseOfDeath(PlayerControllerB player, AdvancedCauseOfDeath? causeOfDeath)`
-    - Applies a given cause of death to the player by their client ID.
-    - Provide the `AdvancedCauseOfDeath` via argument. `AdvancedCauseOfDeath` has static constants for all the vanilla causes of death, or you can use one created by `Coroner.API.Register()`.
-- `Coroner.API.SetCauseOfDeath(int playerId, AdvancedCauseOfDeath? causeOfDeath)`
     - Applies a given cause of death to the player by reference.
     - Provide the `AdvancedCauseOfDeath` via argument. `AdvancedCauseOfDeath` has static constants for all the vanilla causes of death, or you can use one created by `Coroner.API.Register()`.
+- `Coroner.API.SetCauseOfDeath(int playerId, AdvancedCauseOfDeath? causeOfDeath)`
+    - Applies a given cause of death to the player by their client ID.
+    - Provide the `AdvancedCauseOfDeath` via argument. `AdvancedCauseOfDeath` has static constants for all the vanilla causes of death, or you can use one created by `Coroner.API.Register()`.
+- `Coroner.API.ResetCauseOfDeath(PlayerControllerB player)`
+    - Resets the cause of death of the player by reference.
+    - Sets the cause of death to null.
+- `Coroner.API.ResetCauseOfDeath(int playerId)`
+    - Resets the cause of death of the player by their client ID.
+    - Sets the cause of death to null.
 - `Coroner.API.StringifyCauseOfDeath(AdvancedCauseOfDeath causeOfDeath, Random? random)`
     - Translate a cause of death to the user's current language.
     - Pass this the result of `Coroner.API.GetCauseOfDeath()` for best results.


### PR DESCRIPTION
Closes #66
(I think) Closes #57 

Adds in two methods to the API, `void ResetCauseOfDeath(int playerId)` and `void ResetCauseOfDeath(PlayerControllerB player)`.

`SetCauseOfDeath` is unchanged aside from wording in the summary. Currently, if `null` is passed to `SetCauseOfDeath` then it will still correctly be rejected, as `forceOverride` will never be true.
The only issue I can forsee is that if there are existing mods that hook into `AdvancedDeathTracker` ***without*** using the public API, the issue you mentioned about accidentally passing null could arise. This would still require `forceOverride` to be true.
This could be rectified by more extensively editing existing functionality, like straight up having a separate Rpc for `ResetCauseOfDeath` to call, however I'm unsure if any mods DO use the private `AdvancedDeathTracker` in that way so I figured it would be best to preserve existing code as much as possible. Let me know if you want me to find another way instead though.

I also need to do more testing just to make sure this works as expected, so will leave as a draft PR until I do so - but please let me know of any changes you'd want in the meantime in order to accept.
